### PR TITLE
Add Travis Ci build status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/K-Sato1995/spell_generator.svg?branch=master)](https://travis-ci.org/K-Sato1995/spell_generator)
+
 # SpellGenerator
 This is a pretty useless gem I created for practice.
 


### PR DESCRIPTION
This PR adds Travis Ci build status as suggested in #2.

### In case you wonder how I got the image build:
Got build image link from https://travis-ci.org/K-Sato1995/spell_generator by clicking the build image and selecting markdown instead of IMAGE URL.